### PR TITLE
Fixed Issue #378

### DIFF
--- a/css/react-datetime.css
+++ b/css/react-datetime.css
@@ -8,7 +8,7 @@
 .rdtPicker {
   display: none;
   position: absolute;
-  width: 250px;
+  width: inherit;
   padding: 4px;
   margin-top: 1px;
   z-index: 99999 !important;


### PR DESCRIPTION
### Description
Changed width of rdtPicker from 250px to inherit. This will avoid the DateTimePicker(calendar) from overflowing, and will fix it.

### Motivation and Context
The DateTimePicker overflows, as shown in the image in the [issue #378](https://github.com/YouCanBookMe/react-datetime/issues/378)